### PR TITLE
Highways return entire highway's aggregate lat/lngs

### DIFF
--- a/entities/Highway.php
+++ b/entities/Highway.php
@@ -31,7 +31,7 @@ class Highway {
    * Gets all the stations for this highway, and concatenates their JSON segments together
    * into a single giant JSON polyline, saving that into the $fullGeoJson field.
    */
-  function buildBigLine() {
+  private function buildBigLine() {
     $output = new \stdClass();
     $output->type = "Linestring";
     $output->coordinates = array();
@@ -65,7 +65,7 @@ class Highway {
    * @return [Highway] Useful highways.
    */
   public static function fetchAll() {
-    $hs = DB::instance()->highways->fetchAll();
+    $hs = DB::instance()->highwaysHavingStations->fetchAll();
     foreach($hs as $elem) {
       $elem->buildBigLine();
     }

--- a/entities/Highway.php
+++ b/entities/Highway.php
@@ -14,12 +14,32 @@ class Highway {
   public $direction;
   public $highwayname;
   public $bound;
+  public $fullGeoJson;
 
   // Hide some of the params that the client won't need.
   protected $highwaylength;
   protected $startmp;
   protected $endmp;
 
+
+  /**
+   * Gets all the stations for this highway, and concatenates their JSON segments together
+   * into a single giant JSON polyline, saving that into the $fullGeoJson field.
+   */
+  function buildBigLine() {
+    $output = new \stdClass();
+    $output->type = "Linestring";
+    $output->coordinates = array();
+
+    $ss = OrderedStation::fetchForHighway($this->highwayid);
+    foreach($ss as $ts) {
+      foreach($ts->geojson_raw->coordinates as $tc) {
+        $output->coordinates[] = $tc;
+      }
+    }
+
+    $this->fullGeoJson = $output;
+  }
 
   /******************************************************************************
    * STATIC CLASS METHODS

--- a/entities/HighwaysHavingStation.php
+++ b/entities/HighwaysHavingStation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Routelandia\Entities;
+
+/**
+ * Simply a different view, containing all Highway data.
+ * So we'll just make it do exactly what a highway does.
+ */
+class HighwaysHavingStation extends Highway {
+
+}

--- a/migrations.sql
+++ b/migrations.sql
@@ -58,3 +58,19 @@ CREATE VIEW orderedStations AS WITH RECURSIVE stations_by_highway AS
   )
 )
 SELECT * from stations_by_highway ORDER BY linked_list_position;
+
+
+-- VIEW: highwaysWithStations
+-- This view allows us to scope only stations which actually have stations attached to them.
+-- This is useful because a large number of the highways have no stations somehow, and are thus
+-- useless for our purposes.
+-- This also filters out any stations that don't have a segment_raw. We won't be able to draw
+-- them, so the client app doesn't want them.
+DROP VIEW highwaysHavingStations;
+CREATE VIEW highwaysHavingStations AS
+  SELECT highways.*
+  FROM highways
+    JOIN stations ON stations.highwayid=highways.highwayid
+      AND stations.segment_raw != ''
+  GROUP BY highways.highwayid
+  HAVING count(distinct stations.stationid)>0;


### PR DESCRIPTION
This branch allows highways to build an aggregate lat/lng string composed of the lat/lng of each of their stations.

Then it makes this value returned as part of the default representation of a highway.

It also scopes the /api/highways index route to include only highways which actually have stations.
NOTE that before deploying this change to staging (merging to master) the migrations.sql file's "highwaysHavingStations" view needs to be created on the staging server's database!