### PR TITLE
Error handling

### DIFF
--- a/entities/A_Station.php
+++ b/entities/A_Station.php
@@ -37,7 +37,7 @@ class Station {
   public static function fetchAll() {
     $ss = DB::instance()->stations()->fetchAll();
     if(!$ss)
-      throw new RestException(500, "Could not fetch Stations");
+      throw new RestException(500, "Internal server error: Could not fetch Stations");
     //This should *hopefully* never happen
 
     /* If stations start using decoded JSON rather than just raw

--- a/entities/A_Station.php
+++ b/entities/A_Station.php
@@ -95,7 +95,7 @@ class Station {
    * @return int -1 if not possible, otherwise the ID that the onramp *should* be.
    */
   public static function calculateRelatedOnrampID($tid) {
-    if($tid >= 1000 && $tid < 4000) {
+    if($tid < 4000 && $tid >= 1000 ) {
       // First we strip it down to the base ID. (not in the thousands range.)
       while($tid > 1000) {
         $tid = $tid-1000;

--- a/entities/A_Station.php
+++ b/entities/A_Station.php
@@ -2,6 +2,7 @@
 
 namespace Routelandia\Entities;
 
+use Luracast\Restler\RestException;
 use Respect\Relational\Mapper;
 use Routelandia\DB;
 
@@ -52,6 +53,8 @@ class Station {
    */
   public static function fetch($id) {
     $s = DB::instance()->stations[$id]->fetch();
+    if(is_bool($s))
+      throw new RestException(404, "Station ID not found");
     // Might need this later if we want decoded segments
     //$s->decodeSegmentsJson();
     return $s;

--- a/entities/A_Station.php
+++ b/entities/A_Station.php
@@ -36,7 +36,7 @@ class Station {
    */
   public static function fetchAll() {
     $ss = DB::instance()->stations()->fetchAll();
-    if(is_bool($ss))
+    if(!$ss)
       throw new RestException(500, "Could not fetch Stations");
     //This should *hopefully* never happen
 
@@ -57,7 +57,7 @@ class Station {
    */
   public static function fetch($id) {
     $s = DB::instance()->stations[$id]->fetch();
-    if(is_bool($s))
+    if(!$s)
       throw new RestException(404, "Station ID not found");
     // Might need this later if we want decoded segments
     //$s->decodeSegmentsJson();

--- a/entities/A_Station.php
+++ b/entities/A_Station.php
@@ -36,6 +36,10 @@ class Station {
    */
   public static function fetchAll() {
     $ss = DB::instance()->stations()->fetchAll();
+    if(is_bool($ss))
+      throw new RestException(500, "Could not fetch Stations");
+    //This should *hopefully* never happen
+
     /* If stations start using decoded JSON rather than just raw
      * Segments then we'll need this.
     foreach($ss as $elem) {

--- a/entities/Detector.php
+++ b/entities/Detector.php
@@ -61,7 +61,7 @@ class Detector{
    */
   public static function fetch($id) {
     $d = DB::instance()->detectors()[$id]->fetch();
-    if(is_bool($d))
+    if(!$d)
       throw new RestException(404, "Detector ID not found");
     return $d;
   }

--- a/entities/Detector.php
+++ b/entities/Detector.php
@@ -74,6 +74,10 @@ class Detector{
    * This should probably be a method on Station rather than here, but for now this works.
    */
   public static function fetchForStation($stationid) {
-    return DB::instance()->detectors(array('stationid='=>$stationid))->fetchAll();
+    $d = DB::instance()->detectors(array('stationid='=>$stationid))->fetchAll();
+    if(empty($d))
+      throw new RestException(404, "Station ID not found");
+    return $d;
   }
+
 }

--- a/entities/Detector.php
+++ b/entities/Detector.php
@@ -1,6 +1,7 @@
 <?php
 namespace Routelandia\Entities;
 
+use Luracast\Restler\RestException;
 use Respect\Relational\Mapper;
 use Routelandia\DB;
 
@@ -59,7 +60,10 @@ class Detector{
    * Return the detector with the given ID.
    */
   public static function fetch($id) {
-    return DB::instance()->detectors()[$id]->fetch();
+    $d = DB::instance()->detectors()[$id]->fetch();
+    if(is_bool($d))
+      throw new RestException(404, "Detector ID not found");
+    return $d;
   }
 
 

--- a/entities/Highway.php
+++ b/entities/Highway.php
@@ -81,7 +81,10 @@ class Highway {
    *
    * Will return whichever highwayID you request, regardless of if it's "useful" or not.
    *
+   * @param $id
    * @return Highway The Highway entity representation.
+   * @throws RestException
+   * @throws \Routelandia\Exception
    */
   public static function fetch($id) {
     $h = DB::instance()->highways[$id]->fetch();

--- a/entities/Highway.php
+++ b/entities/Highway.php
@@ -38,7 +38,7 @@ class Highway {
     $output->coordinates = array();
 
     $ss = OrderedStation::fetchForHighway($this->highwayid);
-    if(is_bool($ss))
+    if(!$ss)
       throw new RestException(404,"Invalid highwayID");
     foreach($ss as $ts) {
       // This is sort of a bad hack. It results in the fullGeoJson object being present, but not
@@ -64,11 +64,14 @@ class Highway {
    *
    * Scopes highways to only those highways which actually have stations attached to them.
    * (We don't have much use for a highway with no stations in the context of this app...)
-   *
-   * @return [Highway] Useful highways.
+   * @return  [Highway] Useful highways.
+   * @throws RestException
+   * @throws \Routelandia\Exception
    */
   public static function fetchAll() {
     $hs = DB::instance()->highwaysHavingStations->fetchAll();
+    if(!$hs)
+      throw new RestException(500, "Internal server error: Could not reach database");
     foreach($hs as $elem) {
       $elem->buildBigLine();
     }
@@ -88,7 +91,7 @@ class Highway {
    */
   public static function fetch($id) {
     $h = DB::instance()->highways[$id]->fetch();
-    if(is_bool($h))
+    if(!$h)
       throw new RestException(404, "Highway ID not found");
     $h->buildBigLine();
     return $h;

--- a/entities/Highway.php
+++ b/entities/Highway.php
@@ -2,6 +2,7 @@
 
 namespace Routelandia\Entities;
 
+use Luracast\Restler\RestException;
 use Respect\Relational\Mapper;
 use Routelandia\DB;
 
@@ -37,6 +38,8 @@ class Highway {
     $output->coordinates = array();
 
     $ss = OrderedStation::fetchForHighway($this->highwayid);
+    if(is_bool($ss))
+      throw new RestException(404,"Invalid highwayID");
     foreach($ss as $ts) {
       // This is sort of a bad hack. It results in the fullGeoJson object being present, but not
       // having any coordinates.
@@ -82,6 +85,8 @@ class Highway {
    */
   public static function fetch($id) {
     $h = DB::instance()->highways[$id]->fetch();
+    if(is_bool($h))
+      throw new RestException(404, "Highway ID not found");
     $h->buildBigLine();
     return $h;
   }

--- a/entities/OrderedStation.php
+++ b/entities/OrderedStation.php
@@ -2,6 +2,7 @@
 
 namespace Routelandia\Entities;
 
+use Luracast\Restler\RestException;
 use Respect\Relational\Mapper;
 use Routelandia\DB;
 
@@ -60,8 +61,9 @@ class OrderedStation extends Station {
    *       in the meantime this gets the JSON out to the API
    *       so the client team can continue to move forward.
    */
-  private function decodeSegmentsJson() {
-    $this->geojson_raw = json_decode($this->segment_raw);
+  public function decodeSegmentsJson() {
+    if(is_bool($this->geojson_raw = json_decode($this->segment_raw)))
+      throw new RestException(500,"Invalid ID request");
   }
 
 
@@ -115,6 +117,8 @@ class OrderedStation extends Station {
    */
   public static function fetch($id) {
     $s = DB::instance()->orderedStations(array('stationid='=>$id))->fetch();
+    if(is_bool($s))
+      throw new RestException(404, "Invalid stationID request");
     $s->decodeSegmentsJson();
     return $s;
   }
@@ -130,6 +134,9 @@ class OrderedStation extends Station {
     // TODO: This should use stations()->highways[$id] instead of hardcoding 'highwayid'.
     //         Unfortunately that seems to throw an error in Mapper.
     $ss = DB::instance()->orderedStations(array('highwayid='=>$hid))->fetchAll();
+    if(is_bool($ss))
+      throw new RestException(404, "Highway ID not found");
+
     foreach($ss as $elem) {
       $elem->decodeSegmentsJson();
     }

--- a/entities/OrderedStation.php
+++ b/entities/OrderedStation.php
@@ -103,6 +103,8 @@ class OrderedStation extends Station {
    */
   public static function fetchAll() {
     $ss = DB::instance()->orderedStations()->fetchAll();
+    if(!$ss)
+      throw new RestException(500, "Internal server error: Database not found");
     foreach($ss as $elem) {
       $elem->decodeSegmentsJson();
     }

--- a/entities/OrderedStation.php
+++ b/entities/OrderedStation.php
@@ -63,7 +63,7 @@ class OrderedStation extends Station {
    */
   public function decodeSegmentsJson() {
     if(is_bool($this->geojson_raw = json_decode($this->segment_raw)))
-      throw new RestException(500,"Invalid ID request");
+      throw new RestException(404,"Invalid ID request");
   }
 
 

--- a/entities/OrderedStation.php
+++ b/entities/OrderedStation.php
@@ -117,7 +117,7 @@ class OrderedStation extends Station {
    */
   public static function fetch($id) {
     $s = DB::instance()->orderedStations(array('stationid='=>$id))->fetch();
-    if(is_bool($s))
+    if(!$s)
       throw new RestException(404, "Invalid stationID request");
     $s->decodeSegmentsJson();
     return $s;
@@ -134,7 +134,7 @@ class OrderedStation extends Station {
     // TODO: This should use stations()->highways[$id] instead of hardcoding 'highwayid'.
     //         Unfortunately that seems to throw an error in Mapper.
     $ss = DB::instance()->orderedStations(array('highwayid='=>$hid))->fetchAll();
-    if(is_bool($ss))
+    if(!$ss)
       throw new RestException(404, "Highway ID not found");
 
     foreach($ss as $elem) {

--- a/public/Highways.php
+++ b/public/Highways.php
@@ -43,11 +43,15 @@ class Highways {
    *
    * @access public
    * @param int $id Highway ID
-   * @return [Station]
+   * @return  [Station]
+   * @throws \Luracast\Restler\RestException
    * @url GET {id}/stations
    */
   public function getStations($id) {
-    return OrderedStation::fetchForHighway($id);
+    $h = OrderedStation::fetchForHighway($id);
+    if(empty($h))
+      throw new \Luracast\Restler\RestException(404, "Highway ID not found");
+    return $h;
   }
 
 }

--- a/public/Stations.php
+++ b/public/Stations.php
@@ -51,8 +51,9 @@ class Stations {
    * station model itself!
    *
    * @param int $id The station ID to calculate related onramp ID for
-   * @url GET {id}/relatedonramps
    * @return stdClass
+   * @throws \Luracast\Restler\RestException
+   * @url GET {id}/relatedonramps
    */
   public function getRelatedOnramps($id) {
     $retVal = new stdClass;

--- a/public/Stations.php
+++ b/public/Stations.php
@@ -41,7 +41,6 @@ class Stations {
   }
 
 
-
   /**
    * Return the ID of the related onramp for the given station
    *
@@ -53,11 +52,14 @@ class Stations {
    *
    * @param int $id The station ID to calculate related onramp ID for
    * @url GET {id}/relatedonramps
+   * @return stdClass
    */
   public function getRelatedOnramps($id) {
     $retVal = new stdClass;
     $retVal->stationid = $id;
     $retVal->relatedOnrampId = Routelandia\Entities\Station::calculateRelatedOnrampID($id);
+    if($retVal->relatedOnrampId == null)
+      throw new \Luracast\Restler\RestException(404, "Station ID not found");
     $retVal->relatedOnramps = array ();
     $onRamp = OrderedStation::fetchRelatedOnramps($retVal->relatedOnrampId);
     if ($onRamp){

--- a/public/Stations.php
+++ b/public/Stations.php
@@ -51,7 +51,7 @@ class Stations {
    * station model itself!
    *
    * @param int $id The station ID to calculate related onramp ID for
-   * @return stdClass
+   * @return stdClass $retVal An object containing the ID searched for, the calculated result, and an array of relation onramps.
    * @throws \Luracast\Restler\RestException
    * @url GET {id}/relatedonramps
    */

--- a/public/TrafficStats.php
+++ b/public/TrafficStats.php
@@ -113,7 +113,7 @@ class TrafficStats{
      */
     function isValid($id){
         $s = OrderedStation::fetch($id);
-        if(is_bool($s))
+        if(!$s)
             return false;
         else
             return true;


### PR DESCRIPTION
Attempt at solving #27 

Luckily, Restler in all its majesty will handle errors and HTTP response codes with the RestlerException() function. 

Kind've a hacky way to do error handling, but basically in most cases, if the DB doesn't return anything, PHP turns the object into a boolean. So checking if the object is a boolean is a ok signifier that the ID being request doesn't exist. In other cases PHP would return an empty list, that would require the use of the empty() function to check if the request ID didn't exist. 

Its not very robust error handling but I think it will do for our purposes for now. Hopfully this will make our error messages a bit more sane. 