### PR TITLE
Refactor DB access methods

### DIFF
--- a/entities/A_Station.php
+++ b/entities/A_Station.php
@@ -36,7 +36,7 @@ class Station {
    * @throws \Luracast\Restler\RestException
    */
   public static function fetchAll() {
-    $ss = DB::instance()->stations()->fetchAll();
+    $ss = DB::mapper()->stations()->fetchAll();
     if(!$ss) {
       throw new \Luracast\Restler\RestException(404, "No stations could be found.");
     }
@@ -60,7 +60,7 @@ class Station {
    * @throws \Luracast\Restler\RestException
    */
   public static function fetch($id) {
-    $s = DB::instance()->stations[$id]->fetch();
+    $s = DB::mapper()->stations[$id]->fetch();
     if(!$s) {
       throw new \Luracast\Restler\RestException(404, "Station ID not found");
     }
@@ -83,7 +83,7 @@ class Station {
   public static function fetchForHighway($hid) {
     // TODO: This should use stations()->highways[$id] instead of hardcoding 'highwayid'.
     //         Unfortunately that seems to throw an error in Mapper.
-    $ss = DB::instance()->stations(array('highwayid='=>$hid))->fetchAll();
+    $ss = DB::mapper()->stations(array('highwayid='=>$hid))->fetchAll();
     if(!$ss) {
       throw new \Luracast\Restler\RestException(404, "No stations were found for the highway you requested");
     }

--- a/entities/Detector.php
+++ b/entities/Detector.php
@@ -52,7 +52,7 @@ class Detector{
    * Return all detectors, making no effort to filter them.
    */
   public static function fetchAll() {
-    return DB::instance()->detectors()->fetchAll();
+    return DB::mapper()->detectors()->fetchAll();
   }
 
   /**
@@ -61,7 +61,7 @@ class Detector{
    * @throws \Luracast\Restler\RestException
    */
   public static function fetch($id) {
-    $d = DB::instance()->detectors()[$id]->fetch();
+    $d = DB::mapper()->detectors()[$id]->fetch();
     if(!$d) {
       throw new \Luracast\Restler\RestException(404, "Requested Detector ID not found");
     }
@@ -79,7 +79,7 @@ class Detector{
    * @throws \Luracast\Restler\RestException
    */
   public static function fetchForStation($stationid) {
-    $d = DB::instance()->detectors(array('stationid='=>$stationid))->fetchAll();
+    $d = DB::mapper()->detectors(array('stationid='=>$stationid))->fetchAll();
     if(empty($d)) {
       throw new \Luracast\Restler\RestException(404, "No detectors for the requested Station ID could be found");
     }

--- a/entities/Highway.php
+++ b/entities/Highway.php
@@ -72,7 +72,7 @@ class Highway {
    * @throws \Luracast\Restler\RestException
    */
   public static function fetchAll() {
-    $hs = DB::instance()->highwaysHavingStations->fetchAll();
+    $hs = DB::mapper()->highwaysHavingStations->fetchAll();
     if(!$hs) {
       throw new \Luracast\Restler\RestException(404, "No highways were found.");
     }
@@ -94,7 +94,7 @@ class Highway {
    * @throws \Luracast\Restler\RestException
    */
   public static function fetch($id) {
-    $h = DB::instance()->highways[$id]->fetch();
+    $h = DB::mapper()->highways[$id]->fetch();
     if(!$h) {
       throw new \Luracast\Restler\RestException(404, "Highway ID not found");
     }

--- a/entities/OrderedStation.php
+++ b/entities/OrderedStation.php
@@ -106,7 +106,7 @@ class OrderedStation extends Station {
    * @throws \Luracast\Restler\RestException
    */
   public static function fetchAll() {
-    $ss = DB::instance()->orderedStations()->fetchAll();
+    $ss = DB::mapper()->orderedStations()->fetchAll();
     if(!$ss){
       throw new \Luracast\Restler\RestException(404, "No stations could be found");
     }
@@ -125,7 +125,7 @@ class OrderedStation extends Station {
    * @throws \Luracast\Restler\RestException
    */
   public static function fetch($id) {
-    $s = DB::instance()->orderedStations(array('stationid='=>$id))->fetch();
+    $s = DB::mapper()->orderedStations(array('stationid='=>$id))->fetch();
     if(!$s){
       throw new \Luracast\Restler\RestException(404, "Could not find the stationID requested");
     }
@@ -144,7 +144,7 @@ class OrderedStation extends Station {
   public static function fetchForHighway($hid) {
     // TODO: This should use stations()->highways[$id] instead of hardcoding 'highwayid'.
     //         Unfortunately that seems to throw an error in Mapper.
-    $ss = DB::instance()->orderedStations(array('highwayid='=>$hid))->fetchAll();
+    $ss = DB::mapper()->orderedStations(array('highwayid='=>$hid))->fetchAll();
     if(!$ss) {
       throw new \Luracast\Restler\RestException(404, "No stations for the requested highway could be found");
     }


### PR DESCRIPTION
Swaps out the call to DB::instance() in favor of providing both DB::mapper() and DB::sql(). This allows you to use the SQL builder directly for queries that don't quite fit into the ORM's map of things.