### PR TITLE
Rename A_Station.php to Station to match class name. Closes #49

### DIFF
--- a/database.php
+++ b/database.php
@@ -10,7 +10,7 @@ require_once 'PortalStyle.php';
 // in public/
 foreach (glob("../entities/*.php") as $filename)
 {
-    include $filename;
+    require_once $filename;
 }
 
 // Make "Mapper" easily accessible locally.

--- a/entities/OrderedStation.php
+++ b/entities/OrderedStation.php
@@ -2,6 +2,9 @@
 
 namespace Routelandia\Entities;
 
+// A bit of an ugly hack to get around the class loading order...
+require_once 'Station.php';
+
 use Respect\Relational\Mapper;
 use Respect\Relational\Sql;
 use Routelandia\DB;

--- a/entities/Station.php
+++ b/entities/Station.php
@@ -14,12 +14,6 @@ use Routelandia\DB;
  *   2000's: HOV lane detectors in vancouver. (Or maybe elsewhere later)
  *   3000's: HD Radar detectors.
  *   5000's: Onramp detectors.
- *
- * NOTE: This is defined in a file called A_Station, because the .php file
- * appears to need to come before (alphabetically) the OrderedStation class
- * declaration, otherwise OrderedStation can't seem to find the Station class.
- * This seems odd, to be sure, but I suspect it's one of the gotchas related
- * to __autoload() that the PHP docs warns you about.
  */
 class Station {
 


### PR DESCRIPTION
Changes entity loading to a require_once to prevent double-declarations. Solves the dependency problem (alphabetical loading of subclass first) by manually requiring superclass.